### PR TITLE
Update file.rs

### DIFF
--- a/file.rs
+++ b/file.rs
@@ -5,7 +5,7 @@ use anchor_lang::prelude::*;
 pub struct Lending {
   pub lender: Pubkey,
   pub borrower: Pubkey,
-  pub amount: u8, //@note :: dummy flaw that will be fixed by deeydos via PR to u64
+  pub amount: u64, //@note :: dummy flaw that will be fixed by deeydos via PR to u64
   pub interest_bps: u16,
   pub borrowed_date: i64,
   pub grace_period: i64,


### PR DESCRIPTION
amounts are incorrectly contrained to max size of u8 which is 255, 
That means no one can borrow more than 255 lamports , that doesnt even make sense


change u8 to u64 

Thanks
